### PR TITLE
Indexer shadowing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ private-*.properties
 .classpath
 .DS_Store
 .factorypath
-.project 
+.project
+.idea
+.tool-versions
 zz

--- a/README.md
+++ b/README.md
@@ -97,6 +97,53 @@ Therefore the respective SMP must have the appropriate `Extension` element of th
 Please see the [PD specification](https://docs.peppol.eu/edelivery/directory/PEPPOL-EDN-Directory-1.1.1-2020-10-15.pdf) 
   for a detailed description of the required data format as well as for the REST interface.
 
+## Indexer Shadowing Configuration
+
+The PD Indexer supports shadowing of indexing requests to a downstream replicator service for migration purposes (e.g., PD2 migration). 
+When enabled, successful indexing requests are replicated asynchronously as custom JSON events to a configured downstream URL.
+
+**Configuration properties:**
+
+* **`indexer.shadowing.enabled`** - Enable or disable indexer request shadowing. Defaults to `false`.
+* **`indexer.shadowing.url`** - The downstream URL to send shadow events to. Required if shadowing is enabled.
+* **`indexer.shadowing.timeout.ms`** - HTTP timeout in milliseconds for shadow requests. Defaults to `5000` (5 seconds).
+* **`indexer.shadowing.interval.seconds`** - Interval in seconds for the dispatcher job to process queued events. Defaults to `60` seconds (1 minute).
+* **`indexer.shadowing.secret`** - Optional secret string included in the `X-Shadow-Secret` HTTP header for authentication. If not set, no authentication header is sent.
+
+**Shadow event format:**
+
+Shadow events are sent as HTTP POST requests with JSON payload containing:
+- `eventId` - Unique UUID for idempotency
+- `createdAt` - ISO 8601 timestamp
+- `operation` - Operation type (`CREATE_UPDATE` or `DELETE`)
+- `participantId` - The participant identifier
+- `requestingHost` - The requesting host
+- `clientCertificate` - Object containing:
+  - `sha256Fingerprint` - SHA-256 fingerprint of the client certificate (primary identity)
+  - `subjectDN` - Certificate subject distinguished name
+  - `issuerDN` - Certificate issuer distinguished name
+
+**Operational notes:**
+
+- Shadow events are persisted to disk (`shadow-events.xml`) before dispatch for crash safety
+- A background job dispatches events at the configured interval (default: every 60 seconds)
+- Failed events with non-retryable errors (HTTP 4xx) are moved to a dead-letter queue (`failed-shadow-events.xml`)
+- Failed events with retryable errors (network issues, HTTP 5xx) remain in the queue for automatic retry
+- Shadow failures never affect the original indexing request
+- Assumes single application instance per data directory
+- Optional authentication via `X-Shadow-Secret` header for securing the downstream endpoint
+
+Example configuration:
+
+```ini
+# Indexer shadowing (disabled by default)
+indexer.shadowing.enabled=false
+indexer.shadowing.url=https://pd2-replicator.example.com/shadow-events
+indexer.shadowing.timeout.ms=5000
+indexer.shadowing.interval.seconds=60
+indexer.shadowing.secret=your-secret-token-here
+```
+
 
 # PD Publisher
 

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/config/IndexerMicroTypeConverterRegistrar.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/config/IndexerMicroTypeConverterRegistrar.java
@@ -24,6 +24,8 @@ import com.helger.pd.indexer.index.IndexerWorkItem;
 import com.helger.pd.indexer.index.IndexerWorkItemMicroTypeConverter;
 import com.helger.pd.indexer.reindex.ReIndexWorkItem;
 import com.helger.pd.indexer.reindex.ReIndexWorkItemMicroTypeConverter;
+import com.helger.pd.indexer.shadow.ShadowEvent;
+import com.helger.pd.indexer.shadow.ShadowEventMicroTypeConverter;
 import com.helger.xml.microdom.convert.IMicroTypeConverterRegistrarSPI;
 import com.helger.xml.microdom.convert.IMicroTypeConverterRegistry;
 
@@ -41,5 +43,6 @@ public final class IndexerMicroTypeConverterRegistrar implements IMicroTypeConve
   {
     aRegistry.registerMicroElementTypeConverter (IndexerWorkItem.class, new IndexerWorkItemMicroTypeConverter ());
     aRegistry.registerMicroElementTypeConverter (ReIndexWorkItem.class, new ReIndexWorkItemMicroTypeConverter ());
+    aRegistry.registerMicroElementTypeConverter (ShadowEvent.class, new ShadowEventMicroTypeConverter ());
   }
 }

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/mgr/PDMetaManager.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/mgr/PDMetaManager.java
@@ -16,6 +16,7 @@
  */
 package com.helger.pd.indexer.mgr;
 
+import com.helger.base.string.StringHelper;
 import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +32,12 @@ import com.helger.base.lang.clazz.ClassHelper;
 import com.helger.pd.indexer.businesscard.IPDBusinessCardProvider;
 import com.helger.pd.indexer.lucene.PDLucene;
 import com.helger.pd.indexer.settings.PDServerConfiguration;
+import com.helger.pd.indexer.shadow.FailedShadowEventList;
+import com.helger.pd.indexer.shadow.ShadowEventCreator;
+import com.helger.pd.indexer.shadow.ShadowEventDispatcherJob;
+import com.helger.pd.indexer.shadow.ShadowEventList;
 import com.helger.pd.indexer.storage.PDStorageManager;
+import com.helger.quartz.SimpleScheduleBuilder;
 import com.helger.peppolid.factory.IIdentifierFactory;
 import com.helger.photon.core.interror.InternalErrorBuilder;
 import com.helger.scope.IScope;
@@ -58,6 +64,8 @@ public final class PDMetaManager extends AbstractGlobalSingleton
   private PDLucene m_aLucene;
   private PDStorageManager m_aStorageMgr;
   private PDIndexerManager m_aIndexerMgr;
+  private ShadowEventList m_aShadowEventList;
+  private FailedShadowEventList m_aFailedShadowEventList;
 
   @Deprecated (forRemoval = false)
   @UsedViaReflection
@@ -72,6 +80,37 @@ public final class PDMetaManager extends AbstractGlobalSingleton
       m_aLucene = new PDLucene ();
       m_aStorageMgr = new PDStorageManager (m_aLucene);
       m_aIndexerMgr = new PDIndexerManager (m_aStorageMgr);
+
+      // Initialize shadow event configuration cache (must be called before any shadow event creation)
+      ShadowEventCreator.initializeConfiguration ();
+
+      // Initialize shadow event infrastructure if enabled
+      if (PDServerConfiguration.isIndexerShadowingEnabled ())
+      {
+        LOGGER.info ("Indexer shadowing is ENABLED");
+        final String sShadowURL = PDServerConfiguration.getIndexerShadowingURL ();
+        if (StringHelper.isEmpty (sShadowURL))
+        {
+          LOGGER.error ("Indexer shadowing is enabled but URL is not configured - shadowing will be DISABLED");
+        }
+        else
+        {
+          LOGGER.info ("Shadow target URL: " + sShadowURL);
+          LOGGER.info ("Shadow timeout: " + PDServerConfiguration.getIndexerShadowingTimeoutMS () + "ms");
+
+          m_aShadowEventList = new ShadowEventList ();
+          m_aFailedShadowEventList = new FailedShadowEventList ();
+
+          final int nIntervalSeconds = PDServerConfiguration.getIndexerShadowingIntervalSeconds ();
+          ShadowEventDispatcherJob.schedule (SimpleScheduleBuilder.repeatSecondlyForever (nIntervalSeconds));
+
+          LOGGER.info ("Shadow event dispatcher scheduled (every " + nIntervalSeconds + " second(s))");
+        }
+      }
+      else
+      {
+        LOGGER.info ("Indexer shadowing is DISABLED");
+      }
 
       LOGGER.info (ClassHelper.getClassLocalName (this) + " was initialized");
     }
@@ -157,5 +196,25 @@ public final class PDMetaManager extends AbstractGlobalSingleton
   public static IIdentifierFactory getIdentifierFactory ()
   {
     return IF;
+  }
+
+  /**
+   * @return The shadow event list (live queue), or <code>null</code> if
+   *         shadowing is not enabled.
+   */
+  @Nullable
+  public static ShadowEventList getShadowEventList ()
+  {
+    return getInstance ().m_aShadowEventList;
+  }
+
+  /**
+   * @return The failed shadow event list (DLQ), or <code>null</code> if
+   *         shadowing is not enabled.
+   */
+  @Nullable
+  public static FailedShadowEventList getFailedShadowEventList ()
+  {
+    return getInstance ().m_aFailedShadowEventList;
   }
 }

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/rest/IndexerResource.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/rest/IndexerResource.java
@@ -28,6 +28,7 @@ import com.helger.pd.indexer.clientcert.ClientCertificateValidationResult;
 import com.helger.pd.indexer.clientcert.ClientCertificateValidator;
 import com.helger.pd.indexer.index.EIndexerWorkItemType;
 import com.helger.pd.indexer.mgr.PDMetaManager;
+import com.helger.pd.indexer.shadow.ShadowEventCreator;
 import com.helger.peppolid.IParticipantIdentifier;
 import com.helger.peppolid.factory.IIdentifierFactory;
 import com.helger.url.codec.URLCoder;
@@ -131,6 +132,13 @@ public class IndexerResource
     {
       LOGGER.info (sLogPrefix + "Ignoring duplicate CREATE/UPDATE request for '" + aPI.getURIEncoded () + "'");
     }
+
+    // Create shadow event for downstream replication (after processing is queued)
+    ShadowEventCreator.createShadowEvent (aHttpServletRequest,
+                                          aPI,
+                                          EIndexerWorkItemType.CREATE_UPDATE,
+                                          _getRequestingHost (aHttpServletRequest));
+
     // And done
     return Response.noContent ().build ();
   }
@@ -171,6 +179,13 @@ public class IndexerResource
     {
       LOGGER.info (sLogPrefix + "Ignoring duplicate DELETE request for '" + aPI.getURIEncoded () + "'");
     }
+
+    // Create shadow event for downstream replication (after legacy processing is queued)
+    ShadowEventCreator.createShadowEvent (aHttpServletRequest,
+                                          aPI,
+                                          EIndexerWorkItemType.DELETE,
+                                          _getRequestingHost (aHttpServletRequest));
+
     // And done
     return Response.noContent ().build ();
   }

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/settings/PDServerConfiguration.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/settings/PDServerConfiguration.java
@@ -427,6 +427,59 @@ public final class PDServerConfiguration extends AbstractGlobalSingleton
     return getConfig ().getAsBoolean ("sync.businesscards", false);
   }
 
+  /**
+   * @return <code>true</code> if indexer request shadowing is enabled,
+   *         <code>false</code> otherwise. Defaults to <code>false</code>.
+   */
+  public static boolean isIndexerShadowingEnabled ()
+  {
+    return getConfig ().getAsBoolean ("indexer.shadowing.enabled", false);
+  }
+
+  /**
+   * @return The downstream URL for shadowing indexer requests. May be
+   *         <code>null</code> or empty.
+   */
+  @Nullable
+  public static String getIndexerShadowingURL ()
+  {
+    return getConfig ().getAsString ("indexer.shadowing.url");
+  }
+
+  /**
+   * @return Timeout in milliseconds for shadowing HTTP requests. Defaults to
+   *         5000ms.
+   */
+  @Nonnegative
+  public static int getIndexerShadowingTimeoutMS ()
+  {
+    return getConfig ().getAsInt ("indexer.shadowing.timeout.ms", 5000);
+  }
+
+  /**
+   * @return The interval in seconds for the shadow event dispatcher job.
+   *         Defaults to 60 seconds (1 minute).
+   */
+  @Nonnegative
+  public static int getIndexerShadowingIntervalSeconds ()
+  {
+    final int ret = getConfig ().getAsInt ("indexer.shadowing.interval.seconds", 60);
+    if (ret <= 0)
+      throw new IllegalStateException ("The indexer.shadowing.interval.seconds property must be > 0!");
+    return ret;
+  }
+
+  /**
+   * @return The secret string to be included in the X-Shadow-Secret header
+   *         when sending shadow events. May be <code>null</code> if not
+   *         configured (no authentication).
+   */
+  @Nullable
+  public static String getIndexerShadowingSecret ()
+  {
+    return getConfig ().getAsString ("indexer.shadowing.secret");
+  }
+
   public static boolean isPeppolLookupEnabled ()
   {
     return getConfig ().getAsBoolean ("peppol.lookup.enabled", false);

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/CertificateHelper.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/CertificateHelper.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import java.security.MessageDigest;
+import java.security.cert.X509Certificate;
+import java.util.HexFormat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.helger.base.array.ArrayHelper;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Helper class for extracting and processing client certificate information.
+ *
+ * @author Mikael Aksamit
+ */
+public final class CertificateHelper
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (CertificateHelper.class);
+
+  // Thread-local cache for MessageDigest to avoid repeated getInstance() calls
+  private static final ThreadLocal <MessageDigest> SHA256_DIGEST = ThreadLocal.withInitial ( () -> {
+    try
+    {
+      return MessageDigest.getInstance ("SHA-256");
+    }
+    catch (final Exception ex)
+    {
+      throw new IllegalStateException ("SHA-256 algorithm not available", ex);
+    }
+  });
+
+  private CertificateHelper ()
+  {}
+
+  /**
+   * Extract the client certificate from an HTTP servlet request.
+   *
+   * @param aHttpRequest
+   *        The HTTP request. May not be <code>null</code>.
+   * @return The client certificate, or <code>null</code> if not present.
+   */
+  @Nullable
+  public static X509Certificate extractClientCertificate (@Nonnull final HttpServletRequest aHttpRequest)
+  {
+    final Object aValue = aHttpRequest.getAttribute ("jakarta.servlet.request.X509Certificate");
+    if (aValue == null)
+    {
+      LOGGER.warn ("No client certificates present in the request");
+      return null;
+    }
+
+    if (!(aValue instanceof X509Certificate[] aRequestCerts))
+    {
+      LOGGER.error ("Request certificate attribute is not of type X509Certificate[] but of " + aValue.getClass ());
+      return null;
+    }
+
+    if (ArrayHelper.isEmpty (aRequestCerts))
+    {
+      LOGGER.warn ("Client certificate array is empty");
+      return null;
+    }
+
+    return aRequestCerts[0];
+  }
+
+  /**
+   * Compute the SHA-256 fingerprint of a certificate.
+   *
+   * @param aCert
+   *        The certificate. May not be <code>null</code>.
+   * @return The SHA-256 fingerprint as a lowercase hex string, or
+   *         <code>null</code> if computation failed.
+   */
+  @Nullable
+  public static String computeSHA256Fingerprint (@Nonnull final X509Certificate aCert)
+  {
+    try
+    {
+      final MessageDigest aDigest = SHA256_DIGEST.get ();
+      aDigest.reset (); // Reset state from any previous use
+      final byte [] aFingerprint = aDigest.digest (aCert.getEncoded ());
+      return HexFormat.of ().formatHex (aFingerprint);
+    }
+    catch (final Exception ex)
+    {
+      LOGGER.error ("Failed to compute SHA-256 fingerprint for certificate", ex);
+      return null;
+    }
+  }
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/FailedShadowEventList.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/FailedShadowEventList.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.helger.annotation.Nonnegative;
+import com.helger.annotation.concurrent.ThreadSafe;
+import com.helger.annotation.style.ReturnsMutableCopy;
+import com.helger.base.enforce.ValueEnforcer;
+import com.helger.collection.commons.ICommonsList;
+import com.helger.dao.DAOException;
+import com.helger.photon.io.dao.AbstractPhotonMapBasedWALDAO;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+/**
+ * Persistent dead-letter queue (DLQ) for failed shadow events. Events in this
+ * queue have been rejected by the downstream service with non-retryable errors
+ * and require manual investigation.
+ * <p>
+ * Operators can inspect the failed-shadow-events.xml file to review failures
+ * and manually move events back to the live queue (shadow-events.xml) if
+ * appropriate.
+ * </p>
+ *
+ * @author Mikael Aksamit
+ */
+@ThreadSafe
+public final class FailedShadowEventList extends AbstractPhotonMapBasedWALDAO <IShadowEvent, ShadowEvent> implements
+                                          IFailedShadowEventList
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (FailedShadowEventList.class);
+
+  public FailedShadowEventList () throws DAOException
+  {
+    super (ShadowEvent.class, "failed-shadow-events.xml");
+  }
+
+  public void addFailedEvent (@Nonnull final ShadowEvent aEvent)
+  {
+    ValueEnforcer.notNull (aEvent, "Event");
+    m_aRWLock.writeLocked ( () -> {
+      internalCreateItem (aEvent);
+    });
+    LOGGER.warn ("Added shadow event to DLQ (non-retryable failure): " + aEvent.getEventID ());
+  }
+
+  public void removeFailedEvent (@Nonnull final String sEventID)
+  {
+    ValueEnforcer.notNull (sEventID, "EventID");
+    m_aRWLock.writeLocked ( () -> {
+      internalDeleteItem (sEventID);
+    });
+    if (LOGGER.isDebugEnabled ())
+      LOGGER.debug ("Removed failed shadow event from DLQ: " + sEventID);
+  }
+
+  @Nonnull
+  @ReturnsMutableCopy
+  public ICommonsList <IShadowEvent> getAllFailedEvents ()
+  {
+    return getAll ();
+  }
+
+  @Nonnegative
+  public int getFailedEventCount ()
+  {
+    return size ();
+  }
+
+  @Nullable
+  public IShadowEvent getFailedEventOfID (@Nullable final String sEventID)
+  {
+    return getOfID (sEventID);
+  }
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/IFailedShadowEventList.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/IFailedShadowEventList.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import com.helger.annotation.Nonnegative;
+import com.helger.annotation.style.ReturnsMutableCopy;
+import com.helger.collection.commons.ICommonsList;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+/**
+ * Interface for managing failed shadow events in a dead-letter queue (DLQ).
+ * Events in this queue have been rejected by the downstream service with
+ * non-retryable errors (typically 4xx HTTP status codes) and require manual
+ * investigation.
+ *
+ * @author Mikael Aksamit
+ */
+public interface IFailedShadowEventList
+{
+  /**
+   * Add a failed shadow event to the DLQ.
+   *
+   * @param aEvent
+   *        The event to add. May not be <code>null</code>.
+   */
+  void addFailedEvent (@Nonnull ShadowEvent aEvent);
+
+  /**
+   * Remove a failed shadow event from the DLQ by its ID.
+   *
+   * @param sEventID
+   *        The event ID. May not be <code>null</code>.
+   */
+  void removeFailedEvent (@Nonnull String sEventID);
+
+  /**
+   * Get all failed shadow events.
+   *
+   * @return A copy of all failed events. Never <code>null</code>.
+   */
+  @Nonnull
+  @ReturnsMutableCopy
+  ICommonsList <IShadowEvent> getAllFailedEvents ();
+
+  /**
+   * Get the number of failed events in the DLQ.
+   *
+   * @return The failed event count. Always &ge; 0.
+   */
+  @Nonnegative
+  int getFailedEventCount ();
+
+  /**
+   * Get a specific failed event by its ID.
+   *
+   * @param sEventID
+   *        The event ID. May be <code>null</code>.
+   * @return The event or <code>null</code> if not found.
+   */
+  @Nullable
+  IShadowEvent getFailedEventOfID (@Nullable String sEventID);
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/IShadowEvent.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/IShadowEvent.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import java.time.LocalDateTime;
+
+import com.helger.annotation.Nonempty;
+import com.helger.base.id.IHasID;
+import com.helger.pd.indexer.index.EIndexerWorkItemType;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * Interface for a shadow event that represents an indexer operation to be
+ * replicated to a downstream service during PD2 migration.
+ *
+ * @author Mikael Aksamit (mikael@aksamit.se)
+ */
+public interface IShadowEvent extends IHasID <String>
+{
+  /**
+   * @return The unique event ID (UUID). Never <code>null</code>.
+   */
+  @Nonnull
+  @Nonempty
+  String getEventID ();
+
+  /**
+   * @return When this shadow event was created. Never <code>null</code>.
+   */
+  @Nonnull
+  LocalDateTime getCreatedAt ();
+
+  /**
+   * @return The indexer operation type. Never <code>null</code>.
+   */
+  @Nonnull
+  EIndexerWorkItemType getOperation ();
+
+  /**
+   * @return The participant identifier. Never <code>null</code>.
+   */
+  @Nonnull
+  @Nonempty
+  String getParticipantID ();
+
+  /**
+   * @return The requesting host. Never <code>null</code>.
+   */
+  @Nonnull
+  @Nonempty
+  String getRequestingHost ();
+
+  /**
+   * @return The SHA-256 fingerprint of the client certificate. Never
+   *         <code>null</code>.
+   */
+  @Nonnull
+  @Nonempty
+  String getCertSHA256Fingerprint ();
+
+  /**
+   * @return The subject DN of the client certificate. Never <code>null</code>.
+   */
+  @Nonnull
+  @Nonempty
+  String getCertSubjectDN ();
+
+  /**
+   * @return The issuer DN of the client certificate. Never <code>null</code>.
+   */
+  @Nonnull
+  @Nonempty
+  String getCertIssuerDN ();
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/IShadowEventList.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/IShadowEventList.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import com.helger.annotation.Nonnegative;
+import com.helger.annotation.style.ReturnsMutableCopy;
+import com.helger.collection.commons.ICommonsList;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+/**
+ * Interface for managing shadow events in a persistent queue.
+ *
+ * @author Mikael Aksamit
+ */
+public interface IShadowEventList
+{
+  /**
+   * Add a shadow event to the queue.
+   *
+   * @param aEvent
+   *        The event to add. May not be <code>null</code>.
+   */
+  void addEvent (@Nonnull ShadowEvent aEvent);
+
+  /**
+   * Remove a shadow event from the queue by its ID.
+   *
+   * @param sEventID
+   *        The event ID. May not be <code>null</code>.
+   */
+  void removeEvent (@Nonnull String sEventID);
+
+  /**
+   * Get all pending shadow events.
+   *
+   * @return A copy of all pending events. Never <code>null</code>.
+   */
+  @Nonnull
+  @ReturnsMutableCopy
+  ICommonsList <IShadowEvent> getAllEvents ();
+
+  /**
+   * Get the number of pending events in the queue.
+   *
+   * @return The event count. Always &ge; 0.
+   */
+  @Nonnegative
+  int getEventCount ();
+
+  /**
+   * Get a specific event by its ID.
+   *
+   * @param sEventID
+   *        The event ID. May be <code>null</code>.
+   * @return The event or <code>null</code> if not found.
+   */
+  @Nullable
+  IShadowEvent getEventOfID (@Nullable String sEventID);
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEvent.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEvent.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import java.time.LocalDateTime;
+
+import com.helger.annotation.Nonempty;
+import com.helger.annotation.concurrent.Immutable;
+import com.helger.base.enforce.ValueEnforcer;
+import com.helger.pd.indexer.index.EIndexerWorkItemType;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * Immutable shadow event representing an indexer operation to be replicated to
+ * a downstream service during PD2 migration.
+ *
+ * @author Mikael Aksamit
+ */
+@Immutable
+public final class ShadowEvent implements IShadowEvent
+{
+  private final String m_sEventID;
+  private final LocalDateTime m_aCreatedAt;
+  private final EIndexerWorkItemType m_eOperation;
+  private final String m_sParticipantID;
+  private final String m_sRequestingHost;
+  private final String m_sCertSHA256Fingerprint;
+  private final String m_sCertSubjectDN;
+  private final String m_sCertIssuerDN;
+
+  public ShadowEvent (@Nonnull @Nonempty final String sEventID,
+                      @Nonnull final LocalDateTime aCreatedAt,
+                      @Nonnull final EIndexerWorkItemType eOperation,
+                      @Nonnull @Nonempty final String sParticipantID,
+                      @Nonnull @Nonempty final String sRequestingHost,
+                      @Nonnull @Nonempty final String sCertSHA256Fingerprint,
+                      @Nonnull @Nonempty final String sCertSubjectDN,
+                      @Nonnull @Nonempty final String sCertIssuerDN)
+  {
+    m_sEventID = ValueEnforcer.notEmpty (sEventID, "EventID");
+    m_aCreatedAt = ValueEnforcer.notNull (aCreatedAt, "CreatedAt");
+    m_eOperation = ValueEnforcer.notNull (eOperation, "Operation");
+    m_sParticipantID = ValueEnforcer.notEmpty (sParticipantID, "ParticipantID");
+    m_sRequestingHost = ValueEnforcer.notEmpty (sRequestingHost, "RequestingHost");
+    m_sCertSHA256Fingerprint = ValueEnforcer.notEmpty (sCertSHA256Fingerprint, "CertSHA256Fingerprint");
+    m_sCertSubjectDN = ValueEnforcer.notEmpty (sCertSubjectDN, "CertSubjectDN");
+    m_sCertIssuerDN = ValueEnforcer.notEmpty (sCertIssuerDN, "CertIssuerDN");
+  }
+
+  @Nonnull
+  @Nonempty
+  public String getID ()
+  {
+    return m_sEventID;
+  }
+
+  @Nonnull
+  @Nonempty
+  public String getEventID ()
+  {
+    return m_sEventID;
+  }
+
+  @Nonnull
+  public LocalDateTime getCreatedAt ()
+  {
+    return m_aCreatedAt;
+  }
+
+  @Nonnull
+  public EIndexerWorkItemType getOperation ()
+  {
+    return m_eOperation;
+  }
+
+  @Nonnull
+  @Nonempty
+  public String getParticipantID ()
+  {
+    return m_sParticipantID;
+  }
+
+  @Nonnull
+  @Nonempty
+  public String getRequestingHost ()
+  {
+    return m_sRequestingHost;
+  }
+
+  @Nonnull
+  @Nonempty
+  public String getCertSHA256Fingerprint ()
+  {
+    return m_sCertSHA256Fingerprint;
+  }
+
+  @Nonnull
+  @Nonempty
+  public String getCertSubjectDN ()
+  {
+    return m_sCertSubjectDN;
+  }
+
+  @Nonnull
+  @Nonempty
+  public String getCertIssuerDN ()
+  {
+    return m_sCertIssuerDN;
+  }
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventCreator.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventCreator.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import java.security.cert.X509Certificate;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.helger.annotation.Nonempty;
+import com.helger.base.string.StringHelper;
+import com.helger.datetime.helper.PDTFactory;
+import com.helger.pd.indexer.index.EIndexerWorkItemType;
+import com.helger.pd.indexer.mgr.PDMetaManager;
+import com.helger.pd.indexer.settings.PDServerConfiguration;
+import com.helger.peppolid.IParticipantIdentifier;
+
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Creates shadow events for indexer operations and persists them to the
+ * durable outbox queue. This is called after the indexer has successfully
+ * queued a work item.
+ * <p>
+ * Shadow event creation failures are logged but never propagate to affect the
+ * original request.
+ * </p>
+ * <p>
+ * Configuration values are cached at startup to avoid repeated resolution on
+ * the hot request path.
+ * </p>
+ *
+ * @author Mikael Aksamit
+ */
+public final class ShadowEventCreator
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (ShadowEventCreator.class);
+
+  private static volatile boolean s_bShadowingEnabled = false;
+  private static volatile boolean s_bConfigInitialized = false;
+
+  private ShadowEventCreator ()
+  {}
+
+  /**
+   * Initialize the shadowing configuration cache. Called once at startup from
+   * PDMetaManager.
+   */
+  public static void initializeConfiguration ()
+  {
+    s_bShadowingEnabled = PDServerConfiguration.isIndexerShadowingEnabled ();
+    if (s_bShadowingEnabled)
+    {
+      final String sURL = PDServerConfiguration.getIndexerShadowingURL ();
+      if (StringHelper.isEmpty (sURL))
+      {
+        LOGGER.error ("Indexer shadowing is enabled but URL is not configured - shadowing will be DISABLED");
+        s_bShadowingEnabled = false;
+      }
+    }
+    s_bConfigInitialized = true;
+
+    if (LOGGER.isDebugEnabled ())
+      LOGGER.debug ("Shadow event creator initialized: shadowing " +
+                    (s_bShadowingEnabled ? "ENABLED" : "DISABLED"));
+  }
+
+  /**
+   * Create and persist a shadow event for an indexer operation.
+   *
+   * @param aHttpRequest
+   *        The HTTP servlet request containing the client certificate. May not
+   *        be <code>null</code>.
+   * @param aParticipantID
+   *        The participant identifier. May not be <code>null</code>.
+   * @param eOperation
+   *        The indexer operation type. May not be <code>null</code>.
+   * @param sRequestingHost
+   *        The requesting host. May not be <code>null</code>.
+   */
+  public static void createShadowEvent (@Nonnull final HttpServletRequest aHttpRequest,
+                                        @Nonnull final IParticipantIdentifier aParticipantID,
+                                        @Nonnull final EIndexerWorkItemType eOperation,
+                                        @Nonnull @Nonempty final String sRequestingHost)
+  {
+    // Fast path: check cached config flag (volatile read, no synchronization)
+    if (!s_bShadowingEnabled)
+      return;
+
+    // Defensive: ensure initialization happened
+    if (!s_bConfigInitialized)
+    {
+      LOGGER.error ("Shadow event creator not initialized - skipping event creation");
+      return;
+    }
+
+    try
+    {
+      final X509Certificate aCert = CertificateHelper.extractClientCertificate (aHttpRequest);
+      if (aCert == null)
+      {
+        LOGGER.error ("Cannot create shadow event: no client certificate available");
+        return;
+      }
+
+      final String sSHA256Fingerprint = CertificateHelper.computeSHA256Fingerprint (aCert);
+      if (sSHA256Fingerprint == null)
+      {
+        LOGGER.error ("Cannot create shadow event: failed to compute SHA-256 fingerprint");
+        return;
+      }
+
+      final String sSubjectDN = aCert.getSubjectX500Principal ().getName ();
+      final String sIssuerDN = aCert.getIssuerX500Principal ().getName ();
+
+      final ShadowEvent aEvent = new ShadowEvent (UUID.randomUUID ().toString (),
+                                                  PDTFactory.getCurrentLocalDateTime (),
+                                                  eOperation,
+                                                  aParticipantID.getURIEncoded (),
+                                                  sRequestingHost,
+                                                  sSHA256Fingerprint,
+                                                  sSubjectDN,
+                                                  sIssuerDN);
+
+      final ShadowEventList aEventList = PDMetaManager.getShadowEventList ();
+      if (aEventList == null)
+      {
+        LOGGER.error ("Cannot create shadow event: ShadowEventList not initialized");
+        return;
+      }
+
+      aEventList.addEvent (aEvent);
+
+      if (LOGGER.isInfoEnabled ())
+        LOGGER.info ("Created shadow event " +
+                     aEvent.getEventID () +
+                     " for " +
+                     eOperation.getDisplayName () +
+                     " of " +
+                     aParticipantID.getURIEncoded ());
+    }
+    catch (final Exception ex)
+    {
+      LOGGER.error ("Failed to create shadow event (non-fatal - original request succeeded)", ex);
+    }
+  }
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventDispatcherJob.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventDispatcherJob.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import com.helger.annotation.style.OverrideOnDemand;
+import com.helger.base.enforce.ValueEnforcer;
+import com.helger.base.string.StringHelper;
+import com.helger.collection.commons.CommonsHashMap;
+import com.helger.collection.commons.ICommonsList;
+import com.helger.collection.commons.ICommonsMap;
+import com.helger.datetime.helper.PDTFactory;
+import com.helger.http.CHttp;
+import com.helger.pd.indexer.mgr.PDMetaManager;
+import com.helger.pd.indexer.settings.PDServerConfiguration;
+import com.helger.quartz.*;
+import com.helger.schedule.quartz.GlobalQuartzScheduler;
+import com.helger.schedule.quartz.trigger.JDK8TriggerBuilder;
+import com.helger.servlet.mock.MockHttpServletRequest;
+import com.helger.servlet.mock.OfflineHttpServletRequest;
+import com.helger.web.scope.mgr.WebScopeManager;
+import com.helger.web.scope.util.AbstractScopeAwareJob;
+import jakarta.annotation.Nonnull;
+import jakarta.servlet.ServletContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Quartz job that dispatches pending shadow events from the outbox to the
+ * downstream replicator service. Runs every minute.
+ * <p>
+ * Events that fail with retryable errors (network issues, 5xx) remain in the
+ * queue for retry. Events that fail with non-retryable errors (4xx) are moved
+ * to the dead-letter queue for manual investigation.
+ * </p>
+ *
+ * @author Mikael Aksamit
+ */
+@DisallowConcurrentExecution
+public class ShadowEventDispatcherJob extends AbstractScopeAwareJob
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (ShadowEventDispatcherJob.class);
+  private final ServletContext m_aSC;
+
+  public ShadowEventDispatcherJob ()
+  {
+    m_aSC = WebScopeManager.getGlobalScope ().getServletContext ();
+  }
+
+  @Override
+  @Nonnull
+  @OverrideOnDemand
+  protected MockHttpServletRequest createMockHttpServletRequest ()
+  {
+    return new OfflineHttpServletRequest (m_aSC, false);
+  }
+
+  @Override
+  protected void onExecute (@Nonnull final JobDataMap aJobDataMap,
+                            @Nonnull final IJobExecutionContext aContext) throws JobExecutionException
+  {
+    if (!PDServerConfiguration.isIndexerShadowingEnabled ())
+    {
+      if (LOGGER.isDebugEnabled ())
+        LOGGER.debug ("Indexer shadowing is disabled - skipping dispatcher run");
+      return;
+    }
+
+    final String sDownstreamURL = PDServerConfiguration.getIndexerShadowingURL ();
+    if (StringHelper.isEmpty (sDownstreamURL))
+    {
+      LOGGER.warn ("Indexer shadowing is enabled but URL is not configured - skipping dispatcher run");
+      return;
+    }
+
+    final ShadowEventList aEventList = PDMetaManager.getShadowEventList ();
+    if (aEventList == null)
+    {
+      LOGGER.error ("ShadowEventList not initialized - skipping dispatcher run");
+      return;
+    }
+
+    final FailedShadowEventList aFailedEventList = PDMetaManager.getFailedShadowEventList ();
+    if (aFailedEventList == null)
+    {
+      LOGGER.error ("FailedShadowEventList not initialized - skipping dispatcher run");
+      return;
+    }
+
+    final ICommonsList <IShadowEvent> aPendingEvents = aEventList.getAllEvents ();
+    if (aPendingEvents.isEmpty ())
+    {
+      if (LOGGER.isDebugEnabled ())
+        LOGGER.debug ("No pending shadow events to dispatch");
+      return;
+    }
+
+    LOGGER.info ("Dispatching " + aPendingEvents.size () + " shadow event(s) to " + sDownstreamURL);
+
+    int nSuccessCount = 0;
+    int nRetryableFailureCount = 0;
+    int nNonRetryableFailureCount = 0;
+
+    for (final IShadowEvent aEvent : aPendingEvents)
+    {
+      try
+      {
+        final int nStatusCode = ShadowEventSender.sendEvent (sDownstreamURL, aEvent);
+
+        if (nStatusCode >= CHttp.HTTP_OK && nStatusCode < CHttp.HTTP_MULTIPLE_CHOICES)
+        {
+          aEventList.removeEvent (aEvent.getEventID ());
+          nSuccessCount++;
+          LOGGER.info ("Successfully dispatched shadow event " + aEvent.getEventID ());
+        }
+        else
+          if (nStatusCode >= CHttp.HTTP_BAD_REQUEST && nStatusCode < CHttp.HTTP_INTERNAL_SERVER_ERROR)
+          {
+            aEventList.removeEvent (aEvent.getEventID ());
+            aFailedEventList.addFailedEvent ((ShadowEvent) aEvent);
+            nNonRetryableFailureCount++;
+            LOGGER.error ("Shadow event " +
+                          aEvent.getEventID () +
+                          " rejected with HTTP " +
+                          nStatusCode +
+                          " - moved to DLQ");
+          }
+          else
+          {
+            nRetryableFailureCount++;
+            LOGGER.warn ("Shadow event " +
+                         aEvent.getEventID () +
+                         " failed with HTTP " +
+                         nStatusCode +
+                         " - will retry");
+          }
+      }
+      catch (final Exception ex)
+      {
+        nRetryableFailureCount++;
+        LOGGER.warn ("Shadow event " + aEvent.getEventID () + " failed with exception - will retry", ex);
+      }
+    }
+
+    LOGGER.info ("Shadow event dispatch complete: " +
+                 nSuccessCount +
+                 " sent, " +
+                 nRetryableFailureCount +
+                 " retryable failures, " +
+                 nNonRetryableFailureCount +
+                 " moved to DLQ");
+  }
+
+  @Nonnull
+  public static TriggerKey schedule (@Nonnull final SimpleScheduleBuilder aScheduleBuilder)
+  {
+    ValueEnforcer.notNull (aScheduleBuilder, "ScheduleBuilder");
+
+    final ICommonsMap <String, Object> aJobDataMap = new CommonsHashMap <> ();
+
+    return GlobalQuartzScheduler.getInstance ()
+                                .scheduleJob (ShadowEventDispatcherJob.class.getName (),
+                                              JDK8TriggerBuilder.newTrigger ()
+                                                                .startAt (PDTFactory.getCurrentLocalDateTime ()
+                                                                                    .plusSeconds (5))
+                                                                .withSchedule (aScheduleBuilder),
+                                              ShadowEventDispatcherJob.class,
+                                              aJobDataMap);
+  }
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventList.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventList.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.helger.annotation.Nonnegative;
+import com.helger.annotation.concurrent.ThreadSafe;
+import com.helger.annotation.style.ReturnsMutableCopy;
+import com.helger.base.enforce.ValueEnforcer;
+import com.helger.collection.commons.ICommonsList;
+import com.helger.dao.DAOException;
+import com.helger.photon.io.dao.AbstractPhotonMapBasedWALDAO;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+/**
+ * Persistent list of shadow events using Write-Ahead Log DAO pattern. This is
+ * the live queue for events pending dispatch to the downstream service.
+ * <p>
+ * <strong>Important:</strong> This implementation assumes a single application
+ * instance per data directory. If multiple instances share the same data
+ * directory, file corruption may occur.
+ * </p>
+ *
+ * @author Mikael Aksamit
+ */
+@ThreadSafe
+public final class ShadowEventList extends AbstractPhotonMapBasedWALDAO <IShadowEvent, ShadowEvent> implements
+                                   IShadowEventList
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (ShadowEventList.class);
+
+  public ShadowEventList () throws DAOException
+  {
+    super (ShadowEvent.class, "shadow-events.xml");
+  }
+
+  public void addEvent (@Nonnull final ShadowEvent aEvent)
+  {
+    ValueEnforcer.notNull (aEvent, "Event");
+    m_aRWLock.writeLocked ( () -> {
+      internalCreateItem (aEvent);
+    });
+    if (LOGGER.isDebugEnabled ())
+      LOGGER.debug ("Added shadow event to queue: " + aEvent.getEventID ());
+  }
+
+  public void removeEvent (@Nonnull final String sEventID)
+  {
+    ValueEnforcer.notNull (sEventID, "EventID");
+    m_aRWLock.writeLocked ( () -> {
+      internalDeleteItem (sEventID);
+    });
+    if (LOGGER.isDebugEnabled ())
+      LOGGER.debug ("Removed shadow event from queue: " + sEventID);
+  }
+
+  @Nonnull
+  @ReturnsMutableCopy
+  public ICommonsList <IShadowEvent> getAllEvents ()
+  {
+    return getAll ();
+  }
+
+  @Nonnegative
+  public int getEventCount ()
+  {
+    return size ();
+  }
+
+  @Nullable
+  public IShadowEvent getEventOfID (@Nullable final String sEventID)
+  {
+    return getOfID (sEventID);
+  }
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventMicroTypeConverter.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventMicroTypeConverter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import java.time.LocalDateTime;
+
+import com.helger.pd.indexer.index.EIndexerWorkItemType;
+import com.helger.xml.microdom.IMicroElement;
+import com.helger.xml.microdom.MicroElement;
+import com.helger.xml.microdom.convert.IMicroTypeConverter;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+/**
+ * {@link IMicroTypeConverter} implementation for {@link ShadowEvent}
+ *
+ * @author Mikael Aksamit
+ */
+public final class ShadowEventMicroTypeConverter implements IMicroTypeConverter <ShadowEvent>
+{
+  private static final String ATTR_EVENT_ID = "eventid";
+  private static final String ATTR_CREATED_AT = "createdat";
+  private static final String ATTR_OPERATION = "operation";
+  private static final String ATTR_PARTICIPANT_ID = "participantid";
+  private static final String ATTR_REQUESTING_HOST = "requestinghost";
+  private static final String ATTR_CERT_SHA256 = "certsha256";
+  private static final String ATTR_CERT_SUBJECT_DN = "certsubjectdn";
+  private static final String ATTR_CERT_ISSUER_DN = "certissuerdn";
+
+  public IMicroElement convertToMicroElement (@Nonnull final ShadowEvent aValue,
+                                              @Nullable final String sNamespaceURI,
+                                              @Nonnull final String sTagName)
+  {
+    final IMicroElement aElement = new MicroElement (sNamespaceURI, sTagName);
+    aElement.setAttribute (ATTR_EVENT_ID, aValue.getEventID ());
+    aElement.setAttributeWithConversion (ATTR_CREATED_AT, aValue.getCreatedAt ());
+    aElement.setAttribute (ATTR_OPERATION, aValue.getOperation ().getID ());
+    aElement.setAttribute (ATTR_PARTICIPANT_ID, aValue.getParticipantID ());
+    aElement.setAttribute (ATTR_REQUESTING_HOST, aValue.getRequestingHost ());
+    aElement.setAttribute (ATTR_CERT_SHA256, aValue.getCertSHA256Fingerprint ());
+    aElement.setAttribute (ATTR_CERT_SUBJECT_DN, aValue.getCertSubjectDN ());
+    aElement.setAttribute (ATTR_CERT_ISSUER_DN, aValue.getCertIssuerDN ());
+    return aElement;
+  }
+
+  public ShadowEvent convertToNative (@Nonnull final IMicroElement aElement)
+  {
+    final String sEventID = aElement.getAttributeValue (ATTR_EVENT_ID);
+    final LocalDateTime aCreatedAt = aElement.getAttributeValueWithConversion (ATTR_CREATED_AT, LocalDateTime.class);
+    final String sOperationID = aElement.getAttributeValue (ATTR_OPERATION);
+    final EIndexerWorkItemType eOperation = EIndexerWorkItemType.getFromIDOrNull (sOperationID);
+    if (eOperation == null)
+      throw new IllegalStateException ("Failed to parse operation type ID '" + sOperationID + "'");
+
+    final String sParticipantID = aElement.getAttributeValue (ATTR_PARTICIPANT_ID);
+    final String sRequestingHost = aElement.getAttributeValue (ATTR_REQUESTING_HOST);
+    final String sCertSHA256 = aElement.getAttributeValue (ATTR_CERT_SHA256);
+    final String sCertSubjectDN = aElement.getAttributeValue (ATTR_CERT_SUBJECT_DN);
+    final String sCertIssuerDN = aElement.getAttributeValue (ATTR_CERT_ISSUER_DN);
+
+    return new ShadowEvent (sEventID,
+                            aCreatedAt,
+                            eOperation,
+                            sParticipantID,
+                            sRequestingHost,
+                            sCertSHA256,
+                            sCertSubjectDN,
+                            sCertIssuerDN);
+  }
+}

--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventSender.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/shadow/ShadowEventSender.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2015-2025 Philip Helger (www.helger.com)
+ * philip[at]helger[dot]com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.helger.pd.indexer.shadow;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.util.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.helger.annotation.Nonempty;
+import com.helger.http.CHttp;
+import com.helger.httpclient.HttpClientManager;
+import com.helger.httpclient.HttpClientSettings;
+import com.helger.json.IJsonObject;
+import com.helger.json.JsonObject;
+import com.helger.pd.indexer.settings.PDServerConfiguration;
+
+import jakarta.annotation.Nonnull;
+
+/**
+ * Sends shadow events to the downstream replicator service via HTTP POST with
+ * JSON payload.
+ *
+ * @author Mikael Aksamit
+ */
+public final class ShadowEventSender
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (ShadowEventSender.class);
+
+  private ShadowEventSender ()
+  {}
+
+  /**
+   * Build the JSON payload for a shadow event.
+   *
+   * @param aEvent
+   *        The shadow event. May not be <code>null</code>.
+   * @return The JSON object. Never <code>null</code>.
+   */
+  @Nonnull
+  private static IJsonObject _buildEventPayload (@Nonnull final IShadowEvent aEvent)
+  {
+    final IJsonObject aJson = new JsonObject ();
+    aJson.add ("eventId", aEvent.getEventID ());
+    aJson.add ("createdAt", aEvent.getCreatedAt ().toString ());
+    aJson.add ("operation", aEvent.getOperation ().getID ());
+    aJson.add ("participantId", aEvent.getParticipantID ());
+    aJson.add ("requestingHost", aEvent.getRequestingHost ());
+
+    final IJsonObject aCertJson = new JsonObject ();
+    aCertJson.add ("sha256Fingerprint", aEvent.getCertSHA256Fingerprint ());
+    aCertJson.add ("subjectDN", aEvent.getCertSubjectDN ());
+    aCertJson.add ("issuerDN", aEvent.getCertIssuerDN ());
+    aJson.add ("clientCertificate", aCertJson);
+
+    return aJson;
+  }
+
+  /**
+   * Send a shadow event to the downstream service.
+   *
+   * @param sDownstreamURL
+   *        The downstream URL. May not be <code>null</code>.
+   * @param aEvent
+   *        The shadow event to send. May not be <code>null</code>.
+   * @return The HTTP status code returned by the downstream service.
+   * @throws IOException
+   *         If the HTTP request fails
+   */
+  public static int sendEvent (@Nonnull @Nonempty final String sDownstreamURL,
+                               @Nonnull final IShadowEvent aEvent) throws IOException
+  {
+    final IJsonObject aPayload = _buildEventPayload (aEvent);
+    final String sJsonPayload = aPayload.getAsJsonString ();
+
+    if (LOGGER.isDebugEnabled ())
+      LOGGER.debug ("Sending shadow event " + aEvent.getEventID () + " to " + sDownstreamURL);
+
+    final HttpPost aPost = new HttpPost (sDownstreamURL);
+    aPost.setEntity (new StringEntity (sJsonPayload, ContentType.APPLICATION_JSON.withCharset (StandardCharsets.UTF_8)));
+
+    final String sSecret = PDServerConfiguration.getIndexerShadowingSecret ();
+    if (sSecret != null)
+      aPost.setHeader ("X-Shadow-Secret", sSecret);
+
+    final int nTimeoutMS = PDServerConfiguration.getIndexerShadowingTimeoutMS ();
+    final HttpClientSettings aSettings = new HttpClientSettings ();
+    aSettings.setConnectTimeout (Timeout.ofMilliseconds (nTimeoutMS));
+    aSettings.setResponseTimeout (Timeout.ofMilliseconds (nTimeoutMS));
+    try (final HttpClientManager aHttpClientMgr = HttpClientManager.create (aSettings))
+    {
+      final Integer aStatusCode = aHttpClientMgr.execute (aPost, aResponse -> {
+        final int nCode = aResponse.getCode ();
+
+        if (nCode >= CHttp.HTTP_OK && nCode < CHttp.HTTP_MULTIPLE_CHOICES)
+        {
+          if (LOGGER.isDebugEnabled ())
+            LOGGER.debug ("Successfully sent shadow event " + aEvent.getEventID () + " (HTTP " + nCode + ")");
+        }
+        else
+        {
+          LOGGER.warn ("Downstream returned HTTP " + nCode + " for shadow event " + aEvent.getEventID ());
+        }
+
+        return nCode;
+      });
+
+      if (aStatusCode == null)
+        throw new IOException ("HTTP client returned null status code for shadow event " + aEvent.getEventID ());
+
+      return aStatusCode;
+    }
+  }
+}

--- a/phoss-directory-indexer/src/test/java/com/helger/pd/indexer/settings/PDServerConfigurationTest.java
+++ b/phoss-directory-indexer/src/test/java/com/helger/pd/indexer/settings/PDServerConfigurationTest.java
@@ -51,4 +51,11 @@ public final class PDServerConfigurationTest
     final ICommonsList <PDConfiguredTrustStore> aList = PDServerConfiguration.getAllTrustStores ();
     assertEquals (4, aList.size ());
   }
+
+  @Test
+  public void testShadowingDefaults ()
+  {
+    assertEquals (60, PDServerConfiguration.getIndexerShadowingIntervalSeconds ());
+    assertEquals (5000, PDServerConfiguration.getIndexerShadowingTimeoutMS ());
+  }
 }

--- a/phoss-directory-publisher/src/main/resources/application.peppol-prod.properties
+++ b/phoss-directory-publisher/src/main/resources/application.peppol-prod.properties
@@ -102,3 +102,10 @@ peppol.lookup.enabled=true
 
 aws.export.s3.bucket=openpeppol-production-directory-sml-web
 aws.export.s3.publicurl=https://directory-static.peppol.eu/
+
+# Indexer feature (values replaced by deployment script)
+indexer.shadowing.enabled=false
+indexer.shadowing.url=
+indexer.shadowing.timeout.ms=5000
+indexer.shadowing.interval.seconds=60
+indexer.shadowing.secret=

--- a/phoss-directory-publisher/src/main/resources/application.peppol-test.properties
+++ b/phoss-directory-publisher/src/main/resources/application.peppol-test.properties
@@ -102,3 +102,10 @@ peppol.lookup.enabled=false
 
 aws.export.s3.bucket=openpeppol-production-directory-smk-web
 aws.export.s3.publicurl=https://test-directory-static.peppol.eu/
+
+# Indexer feature (values replaced by deployment script)
+indexer.shadowing.enabled=false
+indexer.shadowing.url=
+indexer.shadowing.timeout.ms=5000
+indexer.shadowing.interval.seconds=60
+indexer.shadowing.secret=


### PR DESCRIPTION
Added shadow feature that can be enabled by configuration.

If enabled, any indexing requests will be scheduled asynchronously to be replicated to a downstream service as specified in the properties. A simple authentication mechanism can also be enabled which will inject secret value in a specific custom header.

Example of contents of body that replicates an indexing request:
```json
{
  "eventId": "90219621-ae9f-4265-94fa-5b4610ee8076",
  "createdAt": "2026-04-09T00:42:30.371931537",
  "operation": "create",
  "participantId": "iso6523-actorid-upis::0088:ABC123",
  "requestingHost": "1.2.3.4",
  "clientCertificate": {
    "sha256Fingerprint": "some-very-long-and-unreadable-fingerprint",
    "subjectDN": "CN=POP000055,OU=PEPPOL TEST SMP,O=Acme,C=BE",
    "issuerDN": "CN=PEPPOL SERVICE METADATA PUBLISHER TEST CA - G3,OU=FOR TEST ONLY,O=OpenPEPPOL AISBL,C=BE"
  }
}
```