### PR TITLE
Add Cache-Control header and rate limiting on export redirects

### DIFF
--- a/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/settings/PDServerConfiguration.java
+++ b/phoss-directory-indexer/src/main/java/com/helger/pd/indexer/settings/PDServerConfiguration.java
@@ -422,6 +422,12 @@ public final class PDServerConfiguration extends AbstractGlobalSingleton
     return getConfig ().getAsLong ("rest.limit.requestspersecond", -1);
   }
 
+  @Nonnegative
+  public static long getExportMaxRequestsPerDay ()
+  {
+    return getConfig ().getAsLong ("export.limit.requestsperday", 3);
+  }
+
   public static boolean isSyncAllBusinessCards ()
   {
     return getConfig ().getAsBoolean ("sync.businesscards", false);

--- a/phoss-directory-publisher/src/main/java/com/helger/pd/publisher/exportall/ExportAllManager.java
+++ b/phoss-directory-publisher/src/main/java/com/helger/pd/publisher/exportall/ExportAllManager.java
@@ -296,6 +296,7 @@ public final class ExportAllManager
   {
     // Get data directly from S3
     aUR.setRedirect (S3Helper.S3_PUBLIC_URL + INTERNAL_BUSINESSCARDS_XML_FULL);
+    aUR.addCustomResponseHeader ("Cache-Control", "max-age=86400");
   }
 
   @NonNull
@@ -316,6 +317,7 @@ public final class ExportAllManager
   {
     // Get data directly from S3
     aUR.setRedirect (S3Helper.S3_PUBLIC_URL + INTERNAL_BUSINESSCARDS_XML_NO_DOC_TYPES);
+    aUR.addCustomResponseHeader ("Cache-Control", "max-age=86400");
   }
 
   @NonNull
@@ -463,6 +465,7 @@ public final class ExportAllManager
   {
     // Get data directly from S3
     aUR.setRedirect (S3Helper.S3_PUBLIC_URL + INTERNAL_BUSINESSCARDS_JSON);
+    aUR.addCustomResponseHeader ("Cache-Control", "max-age=86400");
   }
 
   private static void _unify (@NonNull @WillNotClose final CSVWriter aCSVWriter)
@@ -568,6 +571,7 @@ public final class ExportAllManager
   {
     // Get data directly from S3
     aUR.setRedirect (S3Helper.S3_PUBLIC_URL + INTERNAL_BUSINESSCARDS_CSV);
+    aUR.addCustomResponseHeader ("Cache-Control", "max-age=86400");
   }
 
   @NonNull
@@ -631,6 +635,7 @@ public final class ExportAllManager
   {
     // Get data directly from S3
     aUR.setRedirect (S3Helper.S3_PUBLIC_URL + INTERNAL_PARTICIPANTS_XML);
+    aUR.addCustomResponseHeader ("Cache-Control", "max-age=86400");
   }
 
   @NonNull
@@ -673,6 +678,7 @@ public final class ExportAllManager
   {
     // Get data directly from S3
     aUR.setRedirect (S3Helper.S3_PUBLIC_URL + INTERNAL_PARTICIPANTS_JSON);
+    aUR.addCustomResponseHeader ("Cache-Control", "max-age=86400");
   }
 
   @NonNull
@@ -707,5 +713,6 @@ public final class ExportAllManager
   {
     // Get data directly from S3
     aUR.setRedirect (S3Helper.S3_PUBLIC_URL + INTERNAL_PARTICIPANTS_CSV);
+    aUR.addCustomResponseHeader ("Cache-Control", "max-age=86400");
   }
 }

--- a/phoss-directory-publisher/src/main/java/com/helger/pd/publisher/exportall/ExportRateLimit.java
+++ b/phoss-directory-publisher/src/main/java/com/helger/pd/publisher/exportall/ExportRateLimit.java
@@ -1,0 +1,33 @@
+package com.helger.pd.publisher.exportall;
+
+import java.time.Duration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.helger.pd.indexer.settings.PDServerConfiguration;
+
+import es.moki.ratelimitj.core.limiter.request.RequestLimitRule;
+import es.moki.ratelimitj.core.limiter.request.RequestRateLimiter;
+import es.moki.ratelimitj.inmemory.request.InMemorySlidingWindowRequestRateLimiter;
+
+public final class ExportRateLimit
+{
+  private static final Logger LOGGER = LoggerFactory.getLogger (ExportRateLimit.class);
+  public static final ExportRateLimit INSTANCE = new ExportRateLimit ();
+
+  private final RequestRateLimiter m_aRateLimiter;
+
+  private ExportRateLimit ()
+  {
+    final long nRequestsPerDay = PDServerConfiguration.getExportMaxRequestsPerDay ();
+    m_aRateLimiter = new InMemorySlidingWindowRequestRateLimiter (RequestLimitRule.of (Duration.ofHours (24),
+                                                                                       nRequestsPerDay));
+    LOGGER.info ("Installed export rate limiter: max " + nRequestsPerDay + " requests per IP per file per 24 hours");
+  }
+
+  public boolean isOverLimit (final String sKey)
+  {
+    return m_aRateLimiter.overLimitWhenIncremented (sKey);
+  }
+}

--- a/phoss-directory-publisher/src/main/java/com/helger/pd/publisher/servlet/ExportDeliveryHttpHandler.java
+++ b/phoss-directory-publisher/src/main/java/com/helger/pd/publisher/servlet/ExportDeliveryHttpHandler.java
@@ -27,9 +27,12 @@ import com.helger.annotation.OverridingMethodsMustInvokeSuper;
 import com.helger.base.state.EContinue;
 import com.helger.collection.commons.CommonsHashMap;
 import com.helger.collection.commons.ICommonsMap;
+import com.helger.http.CHttp;
+import com.helger.http.CHttpHeader;
 import com.helger.io.file.FilenameHelper;
 import com.helger.pd.publisher.CPDPublisher;
 import com.helger.pd.publisher.exportall.ExportAllManager;
+import com.helger.pd.publisher.exportall.ExportRateLimit;
 import com.helger.photon.core.servlet.AbstractObjectDeliveryHttpHandler;
 import com.helger.servlet.response.UnifiedResponse;
 import com.helger.web.scope.IRequestWebScopeWithoutResponse;
@@ -160,6 +163,16 @@ public class ExportDeliveryHttpHandler extends AbstractObjectDeliveryHttpHandler
                                     @NonNull final UnifiedResponse aUnifiedResponse,
                                     @NonNull final String sFilename) throws IOException
   {
+    final String sRateLimitKey = "export:" + aRequestScope.getRemoteAddr () + ":" + sFilename;
+    if (ExportRateLimit.INSTANCE.isOverLimit (sRateLimitKey))
+    {
+      if (LOGGER.isDebugEnabled ())
+        LOGGER.debug ("Export rate limit exceeded for " + sRateLimitKey);
+      aUnifiedResponse.setStatus (CHttp.HTTP_TOO_MANY_REQUESTS)
+                      .addCustomResponseHeader (CHttpHeader.RETRY_AFTER, "86400");
+      return;
+    }
+
     final Consumer <UnifiedResponse> aHandler = HANDLERS.get (sFilename);
     if (aHandler == null)
     {

--- a/phoss-directory-publisher/src/main/resources/application.properties
+++ b/phoss-directory-publisher/src/main/resources/application.properties
@@ -98,6 +98,9 @@ smp.tls.trust-all = false
 # Maximum 2 search requests per second
 rest.limit.requestspersecond=2
 
+# Maximum export downloads per IP per file per 24 hours
+export.limit.requestsperday=3
+
 # Don't sync all business cards
 sync.businesscards = false
 


### PR DESCRIPTION
All /export/* redirect responses now include Cache-Control: max-age=86400 so well-behaved clients cache the redirect for 24 hours.

Per-IP per-file rate limiting (sliding 24h window, default 3 requests) is enforced at the application level via ExportRateLimit. Threshold is configurable via export.limit.requestsperday in application.properties.